### PR TITLE
fixed sizes, removed overflow and commented better

### DIFF
--- a/image-loader.css
+++ b/image-loader.css
@@ -1,10 +1,30 @@
-/*
-CSS Image Loader - a pure CSS image loader without JS or extra HTML element
+/*=============================================================================
+    CSS Image Loader - a pure CSS image loader without JS or extra HTML element
+    Created by github.com/MarketingPipeline
+===============================================================================*/
 
-Created by github.com/MarketingPipeline
-*/
+@import url('https://fonts.googleapis.com/css?family=Rajdhani:300,400,500,600,700');
+@import url('https://fonts.googleapis.com/css?family=Poppins:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i');
+
+/*==============================
+        RESETS
+===============================*/
 * {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+
+body {
+  overflow-x: hidden;
+  text-align: center;
+  line-height: 1.7;
+  font-family: 'Poppins', sans-serif;
+}
+
+h1, p {
+  margin: 10px 0;
 }
 
 img {
@@ -14,6 +34,8 @@ TO-DO: Fix the sizes so this can be applied to other stylesheets without a prope
   position: relative;
   display: block;
   max-width: 100%;
+  width: 100%;
+  object-fit: contain;
   height: auto;
   min-height: 3rem;
   /* background-color shows in the reserved space before image loads */

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@ Delayed loading image
 -->
 <h1>Delayed image loading example (Valid Image SRC)</h1>
 <p>Scroll down to see the invalid source example</p>
-<img src="http://www.deelay.me/3000/https://codetheweb.blog/assets/img/posts/css-advanced-background-images/bg-size-cover.png" width="4000" height="3000" alt="Valid Delayed Source">
+<img src="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1421&q=80" alt="Valid Delayed Source">
 
 
 <h1>Image SRC not found example</h1>
-<img src="https://source.unsplashs.com/4000x300ss0/?burger" width="4000" height="3000" alt="Invalid Source">
+<img src="https://source.unsplashs.com/4000x300ss0/?burger" alt="Invalid Source">


### PR DESCRIPTION
- I fixed the image sizes together with the error image with the object-fit property
- Removed the horizontal overflow which was caused due to having larger image
-  Added more reset rules
-  Left content url as it is for the case of base64 image
- Gave the layout better fonts.